### PR TITLE
fix: partial revert 5b590b8

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2022 pre-commit dev team: Anthony Sottile, Ken Struys
+Copyright (c) 2014 pre-commit dev team: Anthony Sottile, Ken Struys
 Copyright (c) 2022 before-commit dev team: Luís Ferreira and community
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
This makes the old copyright notice as is, unless the original author
deliberately modify it.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>