### PR TITLE
fix: update to go 1.18

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/testing/resources/golang_hooks_repo/go.mod
+++ b/testing/resources/golang_hooks_repo/go.mod
@@ -1,5 +1,5 @@
 module golang-hello-world
 
-go 1.17
+go 1.18
 
 require github.com/BurntSushi/toml v1.1.0

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -668,7 +668,7 @@ def test_additional_golang_dependencies_installed(
     path = make_repo(tempdir_factory, 'golang_hooks_repo')
     config = make_config_from_repo(path)
     # A small go package
-    deps = ['golang.org/x/example/hello']
+    deps = ['golang.org/x/example/hello@latest']
     config['hooks'][0]['additional_dependencies'] = deps
     hook = _get_hook(config, store, 'golang-hook')
     binaries = os.listdir(
@@ -689,7 +689,7 @@ def test_local_golang_additional_dependencies(store):
             'name': 'hello',
             'entry': 'hello',
             'language': 'golang',
-            'additional_dependencies': ['golang.org/x/example/hello'],
+            'additional_dependencies': ['golang.org/x/example/hello@latest'],
         }],
     }
     hook = _get_hook(config, store, 'hello')


### PR DESCRIPTION
Reference: https://tip.golang.org/doc/go1.18
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Required to fix the latest pipeline failures.