### PR TITLE
ci(github): add windows-2022 to os matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-2019
+          - windows-2022
         py:
           - '3.7'
           - '3.8'


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>