### PR TITLE
ci(github): use latest miniconda and build with macos-12 executor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,7 @@ jobs:
       - if: "!startsWith(matrix.os, 'windows')"
         uses: conda-incubator/setup-miniconda@v2.1.1
         with:
+          miniconda-version: "latest"
           auto-update-conda: true
           python-version: ${{ matrix.py }}
           auto-activate-base: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
           - ubuntu-18.04
           - ubuntu-20.04
           - macos-11
+          - macos-12
           - windows-2019
           - windows-2022
         py:


### PR DESCRIPTION
Fix #50 .