### PR TITLE
ci(github): disable intermediate python versions on old os

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,14 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+        exclude:
+          - {os: ubuntu-18.04, py: '3.8'}
+          - {os: ubuntu-18.04, py: '3.9'}
+          - {os: macos-11, py: '3.8'}
+          - {os: macos-11, py: '3.9'}
+          - {os: windows-2019, py: '3.8'}
+          - {os: windows-2019, py: '3.9'}
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.0.2


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>